### PR TITLE
support health check

### DIFF
--- a/examples/enable_healtch_check.go
+++ b/examples/enable_healtch_check.go
@@ -23,7 +23,7 @@ func initDetect() *t1k.Server {
 		Interval:          2,
 		HealthThreshold:   3,
 		UnhealthThreshold: 5,
-		Addresses:         []string{"10.9.32.250:8000", "10.9.32.250:8001"},
+		Addresses:         []string{"1.1.1.1:8000", "1.1.1.2:8001"},
 	}
 	server.UpdateHealthCheckConfig(hcConfig)
 	return server

--- a/health_check.go
+++ b/health_check.go
@@ -1,0 +1,210 @@
+package t1k
+
+import (
+	"time"
+)
+
+type HealthCheckConfig struct {
+	Interval            int64    // default 1s
+	HealthThreshold     int64    // default 5
+	UnhealthThreshold   int64    // default 3
+	Addresses           []string // like ['1.1.1.1:80', '1.1.1.2:8000']
+	Timeout             int64    // default 3000 millisecond
+	HealthCheckProtocol string
+}
+
+type HealthCheckStats struct {
+	Count           uint64
+	ErrorCount      int64
+	Panic           bool
+	LatestErrorInfo string
+	Status          string
+}
+
+type HealthCheckService struct {
+	healthCheckConfig *HealthCheckConfig
+	Stats             *HealthCheckStats
+	exitChan          chan bool
+	configChan        chan *HealthCheckConfig
+}
+
+const (
+	HealthCheckRunningStatus = "running"
+	HealthCheckStoppedStatus = "stopped"
+)
+
+// IsHealth return  health check result
+func (hcs *HealthCheckService) IsHealth() bool {
+	if hcs.Stats.ErrorCount > hcs.healthCheckConfig.UnhealthThreshold {
+		return false
+	}
+	// from unhealth to health
+	if hcs.Stats.ErrorCount < 0 {
+		return false
+	}
+	if hcs.Stats.Panic {
+		return false
+	}
+	return true
+}
+
+// HealthDetailInfo return health check result with detail info
+func (hcs *HealthCheckService) HealthDetailInfo() string {
+	return hcs.Stats.LatestErrorInfo
+}
+
+// HealthCheckStats return health check stats
+func (hcs *HealthCheckService) HealthCheckStats() HealthCheckStats {
+	return *hcs.Stats
+}
+
+// UpdateConfig trigger the health check or update health check config
+func (hcs *HealthCheckService) UpdateConfig(config *HealthCheckConfig) error {
+	healthCheck := &HealthCheckConfig{}
+	if config.Interval <= 0 {
+		healthCheck.Interval = 1
+	} else {
+		healthCheck.Interval = config.Interval
+	}
+
+	if config.UnhealthThreshold <= 0 {
+		healthCheck.UnhealthThreshold = 3
+	} else {
+		healthCheck.UnhealthThreshold = config.UnhealthThreshold
+	}
+
+	if config.HealthThreshold <= 0 {
+		healthCheck.HealthThreshold = 5
+	} else {
+		healthCheck.HealthThreshold = config.HealthThreshold
+	}
+
+	if config.Timeout <= 0 {
+		healthCheck.Timeout = 3000
+	}
+
+	healthCheck.Addresses = config.Addresses
+	hcs.configChan <- healthCheck
+	return nil
+}
+
+// current support t1k protocol
+func (hcs *HealthCheckService) GetHealthCheckProtocol() string {
+	return hcs.healthCheckConfig.HealthCheckProtocol
+}
+
+func (hcs *HealthCheckService) CaclErrorCount(ok bool, info string) {
+	//         unhealth    |    health    unhealth
+	// ____________________0____________x______________->
+	//-                           UnhealthThreshold     +
+	// ErrorCount == 0 is health
+	// 0 < ErrorCount <= UnhealthThreshold is health
+	// ErrorCount > UnhealthThreshold is unhealth
+	// ErrorCount < 0 is unhealth
+
+	if !ok {
+		// already in unhealth, reset
+		if hcs.Stats.ErrorCount < 0 {
+			hcs.Stats.ErrorCount = -hcs.healthCheckConfig.HealthThreshold
+		} else {
+			hcs.Stats.ErrorCount += 1
+			hcs.Stats.LatestErrorInfo = info
+			if hcs.Stats.ErrorCount > hcs.healthCheckConfig.UnhealthThreshold {
+				// in unhealth
+				hcs.Stats.ErrorCount = -hcs.healthCheckConfig.HealthThreshold
+			}
+		}
+	} else {
+		// from unhealth to health
+		if hcs.Stats.ErrorCount < 0 {
+			hcs.Stats.ErrorCount += 1
+		} else if hcs.Stats.ErrorCount-1 < 0 { // health
+			hcs.Stats.ErrorCount = 0
+		} else {
+			hcs.Stats.ErrorCount = 0 //health, reset
+		}
+		hcs.Stats.LatestErrorInfo = ""
+	}
+}
+
+func (hcs *HealthCheckService) ClearStats() {
+	hcs.Stats.Count = 0
+	hcs.Stats.ErrorCount = 0
+	hcs.Stats.LatestErrorInfo = ""
+	hcs.Stats.Panic = false
+	hcs.Stats.Status = HealthCheckStoppedStatus
+}
+
+// Run start a health check go routine.
+// If you want health check enable, need invoke UpdateConfig to trigger.
+func (hcs *HealthCheckService) Run() error {
+	defer func() {
+		if r := recover(); r != nil {
+			// panic need rerun NewHealthCheckService to recover
+			hcs.Stats.Panic = true
+			hcs.Stats.Status = HealthCheckStoppedStatus
+		}
+	}()
+
+	for {
+		config := <-hcs.configChan
+		if hcs.healthCheckConfig != nil {
+			// only single Run instance
+			return nil
+		}
+		hcs.healthCheckConfig = config
+		if hcs.healthCheckConfig != nil {
+			break
+		}
+	}
+rerun:
+
+	hcs.ClearStats()
+	hcs.Stats.Status = HealthCheckRunningStatus
+
+	// init protocol instance
+	var protocolIns HCProtocol
+	switch hcs.healthCheckConfig.HealthCheckProtocol {
+	case HEALTH_CHECK_T1K_PROTOCOL:
+		protocolIns = NewT1KProtocol(hcs.healthCheckConfig.Addresses, hcs.healthCheckConfig.Timeout)
+	default:
+		protocolIns = NewT1KProtocol(hcs.healthCheckConfig.Addresses, hcs.healthCheckConfig.Timeout)
+	}
+
+	tricker := time.NewTicker(time.Duration(hcs.healthCheckConfig.Interval) * time.Second)
+	for {
+		select {
+		case <-tricker.C:
+			hcs.Stats.Count += 1
+			ok, info := protocolIns.Check()
+
+			hcs.CaclErrorCount(ok, info)
+		case config := <-hcs.configChan:
+			hcs.healthCheckConfig = config
+			goto rerun
+		case <-hcs.exitChan:
+			hcs.ClearStats()
+			return nil
+		}
+	}
+}
+
+func (hcs *HealthCheckService) Close() {
+	hcs.exitChan <- true
+	close(hcs.exitChan)
+
+	close(hcs.configChan)
+}
+
+// NewHealthCheckService create new HealthCheckService for health check.
+// After create new health check service, invoke UpdateConfig to update health check
+func NewHealthCheckService() (*HealthCheckService, error) {
+	healthCheckStats := &HealthCheckStats{}
+
+	healthCheckService := &HealthCheckService{
+		Stats:      healthCheckStats,
+		configChan: make(chan *HealthCheckConfig, 1),
+		exitChan:   make(chan bool, 1),
+	}
+	return healthCheckService, nil
+}

--- a/health_check_protocol.go
+++ b/health_check_protocol.go
@@ -1,0 +1,94 @@
+package t1k
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+)
+
+const (
+	HEALTH_CHECK_T1K_PROTOCOL = "t1k"
+)
+
+type HCProtocol interface {
+	Check() (bool, string)
+}
+
+type T1KProtocol struct {
+	Addresses []string
+	Timeout   int64 // Millisecond
+}
+
+type T1kHealthCheckResult struct {
+	OK     bool
+	Server string
+	Info   string
+}
+
+func (t1kProto *T1KProtocol) checkSingle(ctx context.Context, address string, results chan T1kHealthCheckResult) {
+	result := T1kHealthCheckResult{}
+
+	conn, err := net.Dial("tcp", address)
+	if err != nil {
+		result.OK = false
+		result.Info = err.Error()
+		return
+	}
+	defer conn.Close()
+	result.Server = address
+
+	err = DoHeartbeat(conn)
+	if err != nil {
+		result.OK = false
+		result.Info = err.Error()
+	} else {
+		result.OK = true
+	}
+
+	select {
+	case <-ctx.Done():
+		result.OK = false
+		result.Info = "health check timeout"
+		results <- result
+	case results <- result:
+	}
+}
+
+func (t1kProto *T1KProtocol) Check() (bool, string) {
+	addressesNum := len(t1kProto.Addresses)
+	if addressesNum == 0 {
+		return false, "not available address"
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*time.Duration(t1kProto.Timeout))
+	defer cancel()
+
+	results := make(chan T1kHealthCheckResult, addressesNum)
+	for i := 0; i < addressesNum; i++ {
+		go t1kProto.checkSingle(ctx, t1kProto.Addresses[i], results)
+	}
+
+	successNum := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return false, "health check timeout"
+		case result := <-results:
+			if result.OK {
+				successNum++
+				if successNum == addressesNum {
+					return true, ""
+				}
+			} else {
+				return false, fmt.Sprintf("server %s health check error: %s", result.Server, result.Info)
+			}
+		}
+	}
+}
+
+func NewT1KProtocol(addresses []string, timeout int64) *T1KProtocol {
+	return &T1KProtocol{
+		Addresses: addresses,
+		Timeout:   timeout,
+	}
+}

--- a/health_check_test.go
+++ b/health_check_test.go
@@ -1,0 +1,177 @@
+package t1k
+
+import (
+	"errors"
+	"testing"
+)
+
+func InitHealthCheckIns(healthCheckConfig *HealthCheckConfig) (*HealthCheckService, error) {
+	hcs, err := NewHealthCheckService()
+	if err != nil {
+		return nil, errors.New(err.Error())
+	}
+
+	hcs.healthCheckConfig = healthCheckConfig
+	return hcs, nil
+}
+
+func TestCaclErrorCountHealth(t *testing.T) {
+
+	// Interval: 1
+	// UnhealthThreshold: 3
+	// HealthThreshold: 5
+	// Timeout: 3000
+	healthCheckConfig := &HealthCheckConfig{
+		Interval:          1,
+		UnhealthThreshold: 3,
+		HealthThreshold:   5,
+		Timeout:           3000,
+		Addresses:         []string{"1.1.1.1:8000"},
+	}
+
+	hcs, err := InitHealthCheckIns(healthCheckConfig)
+	if err != nil {
+		t.Errorf("InitHealthCheckIns error: %s", err.Error())
+	}
+
+	count := 100000
+	for i := 0; i < count; i++ {
+		hcs.CaclErrorCount(true, "")
+	}
+
+	if int(hcs.HealthCheckStats().ErrorCount) != 0 {
+		t.Errorf("health check ErrorCount incorrect")
+	}
+
+	if !hcs.IsHealth() {
+		t.Errorf("IsHealth incorrect")
+	}
+}
+
+func TestCaclErrorCountUnHealth(t *testing.T) {
+
+	// Interval: 1
+	// UnhealthThreshold: 3
+	// HealthThreshold: 5
+	// Timeout: 3000
+	healthCheckConfig := &HealthCheckConfig{
+		Interval:          1,
+		UnhealthThreshold: 3,
+		HealthThreshold:   5,
+		Timeout:           3000,
+		Addresses:         []string{"1.1.1.1:8000"},
+	}
+
+	hcs, err := InitHealthCheckIns(healthCheckConfig)
+	if err != nil {
+		t.Errorf("InitHealthCheckIns error: %s", err.Error())
+	}
+
+	count := int64(100000)
+	for i := int64(0); i < count; i++ {
+		hcs.CaclErrorCount(false, "")
+	}
+
+	if hcs.HealthCheckStats().ErrorCount != -hcs.healthCheckConfig.HealthThreshold {
+		t.Errorf("health check ErrorCount incorrect")
+	}
+
+	if hcs.IsHealth() {
+		t.Errorf("IsHealth incorrect")
+	}
+}
+
+func TestCaclErrorCount(t *testing.T) {
+	// Interval: 1
+	// UnhealthThreshold: 3
+	// HealthThreshold: 5
+	// Timeout: 3000
+	healthCheckConfig := &HealthCheckConfig{
+		Interval:          1,
+		UnhealthThreshold: 3,
+		HealthThreshold:   5,
+		Timeout:           3000,
+		Addresses:         []string{"1.1.1.1:8000"},
+	}
+
+	hcs, err := InitHealthCheckIns(healthCheckConfig)
+	if err != nil {
+		t.Errorf("InitHealthCheckIns error: %s", err.Error())
+	}
+
+	// ErrorCount is 2
+	errorCount := int64(2)
+	for i := int64(0); i < errorCount; i++ {
+		hcs.CaclErrorCount(false, "error")
+	}
+	if hcs.HealthCheckStats().ErrorCount != errorCount {
+		t.Errorf("ErrorCount incorrect")
+	}
+	if !hcs.IsHealth() {
+		t.Errorf("IsHealth incorrect")
+	}
+
+	// ErrorCount is 0
+	hcs.CaclErrorCount(true, "")
+	if hcs.HealthCheckStats().ErrorCount != 0 {
+		t.Errorf("ErrorCount incorrect")
+	}
+	if !hcs.IsHealth() {
+		t.Errorf("IsHealth incorrect")
+	}
+
+	// ErrorCount is 3
+	errorCount = int64(3)
+	for i := int64(0); i < errorCount; i++ {
+		hcs.CaclErrorCount(false, "error")
+	}
+	if hcs.HealthCheckStats().ErrorCount != errorCount {
+		t.Errorf("ErrorCount incorrect")
+	}
+	if !hcs.IsHealth() {
+		t.Errorf("IsHealth incorrect")
+	}
+
+	// ErrorCount is -5
+	hcs.CaclErrorCount(false, "")
+	if hcs.HealthCheckStats().ErrorCount != -hcs.healthCheckConfig.HealthThreshold {
+		t.Errorf("ErrorCount incorrect")
+	}
+	if hcs.IsHealth() {
+		t.Errorf("IsHealth incorrect")
+	}
+
+	// ErrorCount is -3
+	successCount := int64(2)
+	for i := int64(0); i < successCount; i++ {
+		hcs.CaclErrorCount(true, "")
+	}
+	if hcs.HealthCheckStats().ErrorCount != -hcs.healthCheckConfig.HealthThreshold+successCount {
+		t.Errorf("ErrorCount incorrect")
+	}
+	if hcs.IsHealth() {
+		t.Errorf("IsHealth incorrect")
+	}
+
+	// ErrorCount is -5
+	hcs.CaclErrorCount(false, "")
+	if hcs.HealthCheckStats().ErrorCount != -hcs.healthCheckConfig.HealthThreshold {
+		t.Errorf("ErrorCount incorrect")
+	}
+	if hcs.IsHealth() {
+		t.Errorf("IsHealth incorrect")
+	}
+
+	// ErrorCount is 0
+	successCount = int64(hcs.healthCheckConfig.HealthThreshold)
+	for i := int64(0); i < successCount; i++ {
+		hcs.CaclErrorCount(true, "")
+	}
+	if hcs.HealthCheckStats().ErrorCount != 0 {
+		t.Errorf("ErrorCount incorrect")
+	}
+	if !hcs.IsHealth() {
+		t.Errorf("IsHealth incorrect")
+	}
+
+}


### PR DESCRIPTION
# New Features
## Feature Description
Supports a separate health check service in addition to the heartbeat mechanism.
- Supports multiple health check services (if any service is abnormal, the overall status will return as abnormal).
- Supports configurable health check intervals.
- Supports configuring the healthy threshold (the threshold for recovering from an unhealthy to a healthy state) and the unhealthy threshold.
- Supports configuring the timeout for a single health check.
- Supports controlling the heartbeat interval through the T1K_HEARTBEAT_INTERVAL environment variable.
## Healthy check example
```
server, err := t1k.NewWithPoolSize(os.Getenv("DETECTOR_ADDR"), 10)
if err != nil {
    return nil
}

// enable health check
hcConfig := &t1k.HealthCheckConfig{
    Interval:          2,
    HealthThreshold:   3,
    UnhealthThreshold: 5,
    Addresses:         []string{"1.1.1.1:8000", "1.1.1.2:8001"},
}

// trigger
server.UpdateHealthCheckConfig(hcConfig)

// check health check
server.IsHealth()

// get health check stats
server.HealthCheckStats()
```
# Bug fix
- Fix block process error in `example/main.go`

# 功能新增
## 特性说明
支持在心跳机制之外，支持单独的检测服务健康检查
- 支持多检测服务支持（当存在多检测服务时，如果某一个检测服务异常，整体会返回异常）
- 支持配置健康检查间隔
- 支持配置健康检查的健康阈值（从异常状态恢复至健康状态的阈值）和异常阈值
- 支持配置单次健康检查的超时时间
- 支持通过 `T1K_HEARTBEAT_INTERVAL` 环境变量，控制心跳的时间间隔
## 健康检查使用方法
```
server, err := t1k.NewWithPoolSize(os.Getenv("DETECTOR_ADDR"), 10)
if err != nil {
    return nil
}

// enable health check
hcConfig := &t1k.HealthCheckConfig{
    Interval:          2,
    HealthThreshold:   3,
    UnhealthThreshold: 5,
    Addresses:         []string{"1.1.1.1:8000", "1.1.1.2:8001"},
}

// trigger
server.UpdateHealthCheckConfig(hcConfig)

// check health check
server.IsHealth()

// get health check stats
server.HealthCheckStats()
```
# Bug 修复
- 修复 `example/main.go` 中的拦截判断异常