### PR TITLE
Add SockErrorHandler && putConn bug

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,27 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: t1kgo
+
+on: [push]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.17', '1.20' ]
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Build
+      run: go build -v ./examples/main.go
+
+    - name: Test
+      run: go test -v ./...

--- a/examples/main.go
+++ b/examples/main.go
@@ -7,15 +7,20 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/chaitin/t1k-go"
 )
 
 func initDetect() *t1k.Server {
-	server, err := t1k.NewWithPoolSize(os.Getenv("DETECTOR_ADDR"), 10)
+	server, err := t1k.NewWithPoolSizeWithTimeout(os.Getenv("DETECTOR_ADDR"), 10, 10*time.Second)
 	if err != nil {
 		return nil
 	}
+
+	server.UpdateSockErrorHandler(func(err error) {
+		fmt.Printf("Socket error: %s", err.Error())
+	})
 	return server
 }
 

--- a/server.go
+++ b/server.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/chaitin/t1k-go/detection"
@@ -20,19 +21,45 @@ const (
 )
 
 type Server struct {
-	socketFactory func() (net.Conn, error)
-	poolCh        chan *conn
-	poolSize      int
-	count         int
-	closeCh       chan struct{}
-	logger        *log.Logger
-	mu            sync.Mutex
+	socketFactory   func() (net.Conn, error)
+	poolCh          chan *conn
+	poolSize        int64
+	count           int64
+	closeCh         chan struct{}
+	logger          *log.Logger
+	SocketErrorHook func(error)
+
+	cntlock    sync.Mutex
+	configLock sync.RWMutex
 
 	healthCheck *HealthCheckService
 }
 
+// added by YF-Networks's taochunhua
+func (s *Server) UpdateSockFactory(socketFactory func() (net.Conn, error)) {
+	s.configLock.Lock()
+	defer s.configLock.Unlock()
+	s.socketFactory = socketFactory
+}
+
+// refactor by YF-Networks's yeyunxi
+func (s *Server) CallSockFactory() (net.Conn, error) {
+	s.configLock.RLock()
+	defer s.configLock.RUnlock()
+	return s.callSockFactory()
+}
+
+// added by YF-Networks's yeyunxi
+func (s *Server) callSockFactory() (net.Conn, error) {
+	conn, err := s.socketFactory()
+	if err != nil && s.SocketErrorHook != nil {
+		s.SocketErrorHook(err)
+	}
+	return conn, err
+}
+
 func (s *Server) newConn() error {
-	sock, err := s.socketFactory()
+	sock, err := s.CallSockFactory()
 	if err != nil {
 		return err
 	}
@@ -42,37 +69,47 @@ func (s *Server) newConn() error {
 }
 
 func (s *Server) GetConn() (*conn, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.count < s.poolSize {
-		for i := 0; i < (s.poolSize - s.count); i++ {
-			err := s.newConn()
-			if err != nil {
-				return nil, err
+	var err error
+
+	if atomic.LoadInt64(&s.count) < s.poolSize {
+		s.cntlock.Lock()
+		if s.count < s.poolSize {
+			for i := int64(0); i < (s.poolSize - s.count); i++ {
+				err = s.newConn()
+				if err != nil {
+					break
+				}
 			}
 		}
+		s.cntlock.Unlock()
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	c := <-s.poolCh
+	if c.failing {
+		err = c.tryReconnIfFailed()
+		if err != nil {
+			s.poolCh <- c
+			return nil, err
+		}
+	}
+
 	return c, nil
 }
 
 func (s *Server) PutConn(c *conn) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if c.failing {
-		s.count -= 1
-		c.Close()
-	} else {
-		s.poolCh <- c
-	}
+	s.poolCh <- c
 }
 
 func (s *Server) broadcastHeartbeat() {
-	l := len(s.poolCh)
-	for i := 0; i < l; i++ {
+	for {
 		select {
 		case c := <-s.poolCh:
-			c.Heartbeat()
+			if !c.failing {
+				c.Heartbeat()
+			}
 			s.PutConn(c)
 		default:
 			return
@@ -101,6 +138,8 @@ func (s *Server) runHeartbeatCo() {
 }
 
 func (s *Server) UpdateHealthCheckConfig(config *HealthCheckConfig) error {
+	s.configLock.Lock()
+	defer s.configLock.Unlock()
 	return s.healthCheck.UpdateConfig(config)
 }
 
@@ -117,17 +156,13 @@ func NewFromSocketFactoryWithPoolSize(socketFactory func() (net.Conn, error), po
 	ret := &Server{
 		socketFactory: socketFactory,
 		poolCh:        make(chan *conn, poolSize),
-		poolSize:      poolSize,
+		poolSize:      int64(poolSize),
 		closeCh:       make(chan struct{}),
 		logger:        log.New(os.Stdout, "snserver", log.LstdFlags),
-		mu:            sync.Mutex{},
+		cntlock:       sync.Mutex{},
+		configLock:    sync.RWMutex{},
 	}
-	for i := 0; i < poolSize; i++ {
-		err := ret.newConn()
-		if err != nil {
-			return nil, err
-		}
-	}
+
 	healthCheck, err := NewHealthCheckService()
 	if err != nil {
 		return nil, err
@@ -205,7 +240,7 @@ func (s *Server) DetectRequest(req detection.Request) (*detection.Result, error)
 // blocks until all pending detection is completed
 func (s *Server) Close() {
 	close(s.closeCh)
-	for i := 0; i < s.count; i++ {
+	for i := int64(0); i < s.count; i++ {
 		c, err := s.GetConn()
 		if err != nil {
 			return


### PR DESCRIPTION
- 添加 SockErrorHandler 函数支持，在连接失败时，调用自定义的连接失败处理函数
- 移除连接异常时的计数减少操作，分离连接对象和实际的连接
- 增加默认自带连接超时的 New 函数